### PR TITLE
make the data private to protect it from csm

### DIFF
--- a/memory.lua
+++ b/memory.lua
@@ -47,6 +47,7 @@ function digiline_memory.on_digiline_receive(pos, node, channel, msg)
 				value = MSG_DATA_TOO_LONG
 			else
 				meta:set_string(addr, value)
+				meta:mark_as_private(addr)
 				value = nil -- don't send it back
 			end
 		else


### PR DESCRIPTION
Memory chips are good to store passwords. Ergo their meta should be private.
The channel is not private because the client needs it to create the formspec.